### PR TITLE
add support for custom fluent bit image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,5 +20,8 @@ jobs:
         username: ${{ secrets.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_PASSWORD }}
     
-    - name: Build and push images
+    - name: Build and push operator image
       run: make -f do.mk image-push-operator latest=true release=true
+
+    - name: Build and push fluent-bit image
+      run: make -f do.mk image-push-fluentbit latest=true release=true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: release
 on:
   push:
     tags:
-      - do-v*
+      - v*
 
 jobs:
 

--- a/cmd/fluent-bit-watcher/Dockerfile
+++ b/cmd/fluent-bit-watcher/Dockerfile
@@ -1,3 +1,5 @@
+ARG FLUENTBIT_VERSION=1.8.3
+
 FROM golang:1.13.6-alpine3.11 as buildergo
 RUN mkdir -p /fluent-bit
 RUN mkdir -p /code
@@ -6,7 +8,7 @@ WORKDIR /code
 RUN echo $(ls -al /code)
 RUN CGO_ENABLED=0 go build -i -ldflags '-w -s' -o /fluent-bit/fluent-bit /code/cmd/fluent-bit-watcher/main.go
 
-FROM fluent/fluent-bit:1.8.3
+FROM fluent/fluent-bit:${FLUENTBIT_VERSION}
 LABEL Description="Fluent Bit docker image" Vendor="KubeSphere" Version="1.0"
 
 COPY conf/fluent-bit.conf conf/parsers.conf /fluent-bit/etc/

--- a/do.mk
+++ b/do.mk
@@ -2,6 +2,11 @@ IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 
 FB_VERSION ?= 1.8.7
 
+ifdef release
+	REV = $(shell git rev-list --tags --max-count=1)
+	IMAGE_TAG = $(shell git describe --tags $(REV))
+endif
+
 $(info using image tag: $(IMAGE_TAG))
 
 .PHONY: image-operator

--- a/do.mk
+++ b/do.mk
@@ -1,13 +1,6 @@
-REV ?= $(shell git rev-parse --short HEAD)
-PREFIX ?= do-
-IMAGE_TAG ?= $(REV:$(PREFIX)%=%)
-FB_VERSION ?= 1.8.7
+IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 
-ifdef release
-	REV = $(shell git rev-list --tags --max-count=1)
-	GIT_TAG ?= $(shell git describe --tags $(REV))
-	IMAGE_TAG = $(GIT_TAG:$(PREFIX)%=%)
-endif
+FB_VERSION ?= 1.8.7
 
 $(info using image tag: $(IMAGE_TAG))
 

--- a/do.mk
+++ b/do.mk
@@ -1,6 +1,7 @@
 REV ?= $(shell git rev-parse --short HEAD)
 PREFIX ?= do-
 IMAGE_TAG ?= $(REV:$(PREFIX)%=%)
+FB_VERSION ?= 1.8.7
 
 ifdef release
 	REV = $(shell git rev-list --tags --max-count=1)
@@ -22,4 +23,18 @@ image-push-operator: image-operator
 	docker push digitaloceanapps/fluent-bit-operator:$(IMAGE_TAG)
 ifdef latest
 	docker push digitaloceanapps/fluent-bit-operator:latest
+endif
+
+.PHONY: image-fluentbit
+image-fluentbit:
+	docker build --build-arg FLUENTBIT_VERSION=$(FB_VERSION) -f cmd/fluent-bit-watcher/Dockerfile -t digitaloceanapps/fluent-bit:$(FB_VERSION)-$(IMAGE_TAG) .
+ifdef latest
+	docker tag digitaloceanapps/fluent-bit:$(FB_VERSION)-$(IMAGE_TAG) digitaloceanapps/fluent-bit:latest
+endif
+
+.PHONY: image-push-fluentbit
+image-push-fluentbit: image-fluentbit
+	docker push digitaloceanapps/fluent-bit:$(FB_VERSION)-$(IMAGE_TAG)
+ifdef latest
+	docker push digitaloceanapps/fluent-bit:latest
 endif


### PR DESCRIPTION
Should publish as `digitaloceanapps/fluent-bit:{base fluent bit version}-{repo tag}` which should allow us to publish multiple tags for same base fluentbit version. So for example: `digitaloceanapps/fluent-bit:1.8.7-0.13.0`.

Changed the GH release to just use `v*` tags, since we also need to use our fork as a Go module package, and this makes things saner.