### PR TITLE
update fluent bit version to 1.8.11

### DIFF
--- a/do.mk
+++ b/do.mk
@@ -1,6 +1,6 @@
 IMAGE_TAG ?= $(shell git rev-parse --short HEAD)
 
-FB_VERSION ?= 1.8.7
+FB_VERSION ?= 1.8.11
 
 ifdef release
 	REV = $(shell git rev-list --tags --max-count=1)


### PR DESCRIPTION
Related to #11. 
This should have the fix fluent/fluent-bit@3b9a2e7 in version [v1.8.11](https://fluentbit.io/announcements/v1.8.11/).